### PR TITLE
feat: removes doctype optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ contribute to the project by implementing any of these features.
 
 - [x] Comments
 - [ ] `<desc>` tags
-- [ ] `Doctype`
+- [x] `Doctype`
 - [ ] Editor Data
 - [ ] Empty Attributes
 - [ ] Empty Containers

--- a/crates/svgo/src/bin/cli/mod.rs
+++ b/crates/svgo/src/bin/cli/mod.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use clap::Parser;
 
 use svgo::optimizer::optimization::RemoveCommentsOptimization;
+use svgo::optimizer::optimization::RemoveDoctypeOptimization;
 use svgo::optimizer::Optimization;
 
 #[derive(Debug, Parser)]
@@ -17,7 +18,11 @@ pub struct SvgoCli {
     /// Space separated list of SVGs to optimize
     pub files: Vec<PathBuf>,
     /// Removes Comments from SVG
+    #[clap(long)]
     pub remove_comments: bool,
+    /// Removes DOCTYPE from SVG
+    #[clap(long)]
+    pub remove_doctype: bool,
 }
 
 impl SvgoCli {
@@ -32,6 +37,10 @@ impl SvgoCli {
 
             if self.remove_comments {
                 svgo.add_optimization(Optimization::RemoveComments(RemoveCommentsOptimization));
+            }
+
+            if self.remove_doctype {
+                svgo.add_optimization(Optimization::RemoveDoctype(RemoveDoctypeOptimization));
             }
 
             svgo.optimize()?;

--- a/crates/svgo/src/optimizer/mod.rs
+++ b/crates/svgo/src/optimizer/mod.rs
@@ -5,11 +5,14 @@ use std::collections::HashSet;
 use crate::svg::Svg;
 
 use self::optimization::remove_comments::RemoveCommentsOptimization;
+use self::optimization::remove_doctype::RemoveDoctypeOptimization;
 
 #[derive(Debug, Hash, Eq, PartialEq)]
 pub enum Optimization {
     /// Remove all comments from the SVG document.
     RemoveComments(RemoveCommentsOptimization),
+    /// Remove Doctype declaration from the SVG document.
+    RemoveDoctype(RemoveDoctypeOptimization),
 }
 
 pub struct Optimizer {
@@ -37,6 +40,9 @@ impl Optimizer {
         for optimization in &self.optimizations {
             match optimization {
                 Optimization::RemoveComments(optimization) => {
+                    optimization.apply(svg)?;
+                }
+                Optimization::RemoveDoctype(optimization) => {
                     optimization.apply(svg)?;
                 }
             }

--- a/crates/svgo/src/optimizer/optimization/mod.rs
+++ b/crates/svgo/src/optimizer/optimization/mod.rs
@@ -1,3 +1,5 @@
 pub mod remove_comments;
+pub mod remove_doctype;
 
 pub use remove_comments::RemoveCommentsOptimization;
+pub use remove_doctype::RemoveDoctypeOptimization;

--- a/crates/svgo/src/optimizer/optimization/remove_doctype.rs
+++ b/crates/svgo/src/optimizer/optimization/remove_doctype.rs
@@ -1,0 +1,27 @@
+use crate::svg::{node::Node, Svg};
+
+#[derive(Debug, Default, Hash, Eq, PartialEq)]
+pub struct RemoveDoctypeOptimization;
+
+impl RemoveDoctypeOptimization {
+    pub fn apply(&self, svg: &mut Svg) -> anyhow::Result<()> {
+        svg.0.retain(|node| !matches!(node, Node::Doctype(_)));
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn removes_comments_from_nodes_vector() {
+        let mut svg = Svg(vec![Node::Doctype(String::default())]);
+
+        let optimization = RemoveDoctypeOptimization;
+        optimization.apply(&mut svg).unwrap();
+
+        assert_eq!(svg.0.len(), 0);
+    }
+}


### PR DESCRIPTION
Provides support for removing DOCTYPE.

```
SVG Optimizer

Usage: svgo [OPTIONS] [FILES]...

Arguments:
  [FILES]...
          Space separated list of SVGs to optimize

Options:
      --remove-comments
          Removes Comments from SVG
      --remove-doctype
          Removes DOCTYPE from SVG
  -h, --help
          Print help
```

Having:

```svg
<?xml version="1.0" encoding="UTF-8"?>
<!-- Generator: Adobe Illustrator 15.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->

<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg version="1.1" x="0px" y="0px" width="120px" height="120px" viewBox="0 0 120 120" enable-background="new 0 0 120 120" space="preserve">
    <style type="text/css"><![CDATA[
        svg { fill: red; }
    ]]></style>
    <g>
        <g>
            <circle fill="#ff0000" cx="60px" cy="60px" r="50px" />
            <text>  test  </text>
        </g>
    </g>
    <g style="color: black" class="unknown-class" />
</svg>
```

Executing:

```bash
svgo ./crates/svgo/fixtures/japan.svg --remove-comments --remove-doctype
```

Would result in:

```svg
<?xml version="1.0" encoding="UTF-8"?>


<svg version="1.1" x="0px" y="0px" width="120px" height="120px" viewBox="0 0 120 120" enable-background="new 0 0 120 120" space="preserve">
    <style type="text/css"><![CDATA[
        svg { fill: red; }
    ]]></style>
    <g>
        <g>
            <circle fill="#ff0000" cx="60px" cy="60px" r="50px" />
            <text>  test  </text>
        </g>
    </g>
    <g style="color: black" class="unknown-class" />
</svg>
```